### PR TITLE
Standardize preview URLs on lovebird

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -71,7 +71,7 @@ graph TD
 #### `deploy-master.yml`
 - **Trigger**: Push to master branch
 - **Purpose**: Deploy master to staging environment
-- **Output**: `https://phialo-master.meise.workers.dev`
+- **Output**: `https://phialo-master.lovebird.workers.dev`
 
 #### `deploy-production.yml`
 - **Trigger**: Release published or manual

--- a/.github/workflows/browserstack-pr.yml
+++ b/.github/workflows/browserstack-pr.yml
@@ -85,7 +85,7 @@ jobs:
           BUILD_ID: pr-${{ needs.check-trigger.outputs.pr-number }}-${{ github.run_number }}
           BROWSERSTACK_BUILD_NAME: 'PR #${{ needs.check-trigger.outputs.pr-number }}'
           BROWSERSTACK_PROJECT_NAME: 'Phialo Design'
-          BASE_URL: https://phialo-pr-${{ needs.check-trigger.outputs.pr-number }}.meise.workers.dev
+          BASE_URL: https://phialo-pr-${{ needs.check-trigger.outputs.pr-number }}.lovebird.workers.dev
           
       - name: Upload test results
         if: always()

--- a/.github/workflows/cloudflare-list-and-cleanup-workers.yml
+++ b/.github/workflows/cloudflare-list-and-cleanup-workers.yml
@@ -165,7 +165,7 @@ jobs:
               echo "  • $worker"
               echo "    Created: $CREATED_DATE"
               echo "    Status: $STATUS"
-              echo "    URL: https://${worker}.meise.workers.dev"
+              echo "    URL: https://${worker}.lovebird.workers.dev"
               echo ""
             done
           fi
@@ -184,16 +184,16 @@ jobs:
               # Determine worker type/URL
               if [[ "$worker" == "phialo-design-preview" ]]; then
                 echo "    Type: Preview environment"
-                echo "    URL: https://phialo-design-preview.meise.workers.dev"
+                echo "    URL: https://phialo-design-preview.lovebird.workers.dev"
               elif [[ "$worker" == "phialo-design" ]]; then
                 echo "    Type: Production"
                 echo "    URL: https://phialo.de"
               elif [[ "$worker" == "phialo-master" ]]; then
                 echo "    Type: Master branch deployment"
-                echo "    URL: https://phialo-master.meise.workers.dev"
+                echo "    URL: https://phialo-master.lovebird.workers.dev"
               else
                 echo "    Type: Custom/Unknown"
-                echo "    URL: https://${worker}.meise.workers.dev"
+                echo "    URL: https://${worker}.lovebird.workers.dev"
               fi
               echo ""
             done

--- a/.github/workflows/deploy-command.yml
+++ b/.github/workflows/deploy-command.yml
@@ -179,7 +179,7 @@ jobs:
           if [ "${{ needs.check-command.outputs.environment }}" = "production" ]; then
             echo "deployment_url=https://phialo.de" >> $GITHUB_OUTPUT
           else
-            echo "deployment_url=https://phialo-pr-${{ needs.check-command.outputs.pr_number }}.meise.workers.dev" >> $GITHUB_OUTPUT
+            echo "deployment_url=https://phialo-pr-${{ needs.check-command.outputs.pr_number }}.lovebird.workers.dev" >> $GITHUB_OUTPUT
           fi
       
       - name: Post deployment success
@@ -248,7 +248,7 @@ jobs:
             - All required checks should be passing
             
             **Preview URLs:**
-            - Preview deployments are available at: \`https://phialo-pr-{PR_NUMBER}.meise.workers.dev\`
+            - Preview deployments are available at: \`https://phialo-pr-{PR_NUMBER}.lovebird.workers.dev\`
             - Production deployments are available at: \`https://phialo.de\`
             
             **Notes:**

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       environment: preview
       worker-name: phialo-pr-${{ github.event.pull_request.number }}
-      deployment-url: https://phialo-pr-${{ github.event.pull_request.number }}.meise.workers.dev
+      deployment-url: https://phialo-pr-${{ github.event.pull_request.number }}.lovebird.workers.dev
       pr-number: ${{ github.event.pull_request.number }}
       analytics-enabled: false
       cache-version: v1-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -74,14 +74,14 @@ jobs:
                 exit 1
               fi
               echo "worker-name=phialo-pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
-              echo "deployment-url=https://phialo-pr-${PR_NUMBER}.meise.workers.dev" >> $GITHUB_OUTPUT
+              echo "deployment-url=https://phialo-pr-${PR_NUMBER}.lovebird.workers.dev" >> $GITHUB_OUTPUT
               echo "analytics-enabled=false" >> $GITHUB_OUTPUT
               echo "cache-version=v1-pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
               echo "enable-performance-comment=true" >> $GITHUB_OUTPUT
               ;;
             master)
               echo "worker-name=phialo-master" >> $GITHUB_OUTPUT
-              echo "deployment-url=https://phialo-master.meise.workers.dev" >> $GITHUB_OUTPUT
+              echo "deployment-url=https://phialo-master.lovebird.workers.dev" >> $GITHUB_OUTPUT
               echo "analytics-enabled=true" >> $GITHUB_OUTPUT
               echo "cache-version=v1-master" >> $GITHUB_OUTPUT
               echo "enable-performance-comment=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -50,20 +50,20 @@ jobs:
               isLocal = context.payload.inputs?.test_local === 'true';
               
               if (prNumber) {
-                targetUrl = `https://phialo-pr-${prNumber}.meise.workers.dev`;
+                targetUrl = `https://phialo-pr-${prNumber}.lovebird.workers.dev`;
               } else {
                 // Testing master branch
-                targetUrl = 'https://phialo-master.meise.workers.dev';
+                targetUrl = 'https://phialo-master.lovebird.workers.dev';
               }
             } else {
               // Triggered by workflow_run
               const workflows = context.payload.workflow_run.pull_requests;
               if (workflows && workflows.length > 0) {
                 prNumber = workflows[0].number;
-                targetUrl = `https://phialo-pr-${prNumber}.meise.workers.dev`;
+                targetUrl = `https://phialo-pr-${prNumber}.lovebird.workers.dev`;
               } else {
                 // Workflow run on master branch
-                targetUrl = 'https://phialo-master.meise.workers.dev';
+                targetUrl = 'https://phialo-master.lovebird.workers.dev';
               }
             }
             
@@ -289,20 +289,20 @@ jobs:
               isLocal = context.payload.inputs?.test_local === 'true';
               
               if (prNumber) {
-                targetUrl = `https://phialo-pr-${prNumber}.meise.workers.dev`;
+                targetUrl = `https://phialo-pr-${prNumber}.lovebird.workers.dev`;
               } else {
                 // Testing master branch
-                targetUrl = 'https://phialo-master.meise.workers.dev';
+                targetUrl = 'https://phialo-master.lovebird.workers.dev';
               }
             } else {
               // Triggered by workflow_run
               const workflows = context.payload.workflow_run.pull_requests;
               if (workflows && workflows.length > 0) {
                 prNumber = workflows[0].number;
-                targetUrl = `https://phialo-pr-${prNumber}.meise.workers.dev`;
+                targetUrl = `https://phialo-pr-${prNumber}.lovebird.workers.dev`;
               } else {
                 // Workflow run on master branch
-                targetUrl = 'https://phialo-master.meise.workers.dev';
+                targetUrl = 'https://phialo-master.lovebird.workers.dev';
               }
             }
             
@@ -526,20 +526,20 @@ jobs:
               isLocal = context.payload.inputs?.test_local === 'true';
               
               if (prNumber) {
-                targetUrl = `https://phialo-pr-${prNumber}.meise.workers.dev`;
+                targetUrl = `https://phialo-pr-${prNumber}.lovebird.workers.dev`;
               } else {
                 // Testing master branch
-                targetUrl = 'https://phialo-master.meise.workers.dev';
+                targetUrl = 'https://phialo-master.lovebird.workers.dev';
               }
             } else {
               // Triggered by workflow_run
               const workflows = context.payload.workflow_run?.pull_requests;
               if (workflows && workflows.length > 0) {
                 prNumber = workflows[0].number;
-                targetUrl = `https://phialo-pr-${prNumber}.meise.workers.dev`;
+                targetUrl = `https://phialo-pr-${prNumber}.lovebird.workers.dev`;
               } else {
                 // Workflow run on master branch
-                targetUrl = 'https://phialo-master.meise.workers.dev';
+                targetUrl = 'https://phialo-master.lovebird.workers.dev';
               }
             }
             
@@ -715,7 +715,7 @@ jobs:
           const isLocal = '${{ steps.pr-details.outputs.is_local }}' === 'true';
           const targetUrl = '${{ steps.pr-details.outputs.target_url }}';
           if (!isLocal && targetUrl) {
-            const shortUrl = targetUrl.replace('https://', '').replace('.meise.workers.dev', '');
+            const shortUrl = targetUrl.replace('https://', '').replace('.lovebird.workers.dev', '');
             report += `**Preview URL:** [${shortUrl}](${targetUrl})\n`;
           }
           report += `**Test Date:** ${new Date().toISOString().split('T')[0]}\n\n`;

--- a/.github/workflows/webhook-deploy.yml
+++ b/.github/workflows/webhook-deploy.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           DEPLOYMENT_URL="https://phialo.de"
           if [ "${{ needs.validate-webhook.outputs.environment }}" = "preview" ]; then
-            DEPLOYMENT_URL="https://phialo-design-preview.meise.workers.dev"
+            DEPLOYMENT_URL="https://phialo-design-preview.lovebird.workers.dev"
           fi
           
           # Send callback to webhook sender

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,13 +446,13 @@ Implementation files:
 - **Note**: Requires zone permissions for custom domain
 
 #### Master (`phialo-master`) 
-- **URL**: https://phialo-master.meise.workers.dev
+- **URL**: https://phialo-master.lovebird.workers.dev
 - **Deployment**: Automatic on push to master branch
 - **Purpose**: Latest master branch deployment
 - **Manual Deploy**: Available via GitHub Actions UI
 
 #### Ephemeral PR Previews (`phialo-pr-{number}`)
-- **URL**: https://phialo-pr-{number}.meise.workers.dev
+- **URL**: https://phialo-pr-{number}.lovebird.workers.dev
 - **Deployment**: Automatic on PR creation/update
 - **Cleanup**: Automatic on PR close/merge
 - **Purpose**: Isolated testing for each PR

--- a/ci/build/scripts/deploy-preview.sh
+++ b/ci/build/scripts/deploy-preview.sh
@@ -30,7 +30,7 @@ npx wrangler deploy --env preview
 # Get deployment URL
 echo ""
 echo "→ Getting deployment URL..."
-WORKER_URL="https://phialo-design-preview.meise.workers.dev"
+WORKER_URL="https://phialo-design-preview.lovebird.workers.dev"
 
 # Check if site is accessible
 echo "→ Verifying deployment..."

--- a/docs/decisions/github-environments-for-secrets.md
+++ b/docs/decisions/github-environments-for-secrets.md
@@ -27,7 +27,7 @@ We should create three GitHub environments:
   - `RESEND_API_KEY` (test API key)
   - `FROM_EMAIL` (onboarding@resend.dev)
   - `TO_EMAIL` (test email)
-- **Environment URL**: `https://phialo-pr-*.meise.workers.dev`
+- **Environment URL**: `https://phialo-pr-*.lovebird.workers.dev`
 
 #### Production Environment
 - **Protection Rules**:
@@ -49,7 +49,7 @@ We should create three GitHub environments:
 3. Create `preview` environment:
    ```
    Name: preview
-   Environment URL: https://phialo-pr-${{ github.event.pull_request.number }}.meise.workers.dev
+   Environment URL: https://phialo-pr-${{ github.event.pull_request.number }}.lovebird.workers.dev
    ```
 4. Add environment secrets
 5. Repeat for `production` environment

--- a/docs/how-to/setup-github-environments.md
+++ b/docs/how-to/setup-github-environments.md
@@ -37,7 +37,7 @@ Click **Add secret** for each:
 
 1. **Environment URL**: 
    ```
-   https://phialo-pr-${{ github.event.pull_request.number }}.meise.workers.dev
+   https://phialo-pr-${{ github.event.pull_request.number }}.lovebird.workers.dev
    ```
 
 2. **Deployment branches**:
@@ -107,7 +107,7 @@ When a PR is created:
 1. Workflow runs with `environment: preview`
 2. Uses preview environment secrets (test API key)
 3. No approval required
-4. Deploys to `phialo-pr-{number}.meise.workers.dev`
+4. Deploys to `phialo-pr-{number}.lovebird.workers.dev`
 
 ### Production Deployments
 

--- a/docs/how-to/setup-github-secrets.md
+++ b/docs/how-to/setup-github-secrets.md
@@ -88,7 +88,7 @@ After adding the secrets:
 
 1. Create a new PR or push to an existing PR
 2. Wait for the PR preview deployment to complete
-3. Visit the preview URL (e.g., `https://phialo-pr-123.meise.workers.dev`)
+3. Visit the preview URL (e.g., `https://phialo-pr-123.lovebird.workers.dev`)
 4. Test the contact form - it should now send emails successfully
 
 ## Troubleshooting

--- a/docs/production-launch-guide.md
+++ b/docs/production-launch-guide.md
@@ -52,7 +52,7 @@ zone_id = "YOUR_ZONE_ID"  # MUST REPLACE WITH ACTUAL ZONE ID
 3. Add these domains:
    - phialo.de
    - www.phialo.de
-   - *.meise.workers.dev
+   - *.lovebird.workers.dev
 4. Save the Site Key (public) and Secret Key (private)
 
 ### Phase 2: GitHub Configuration (Day 1-2)
@@ -87,7 +87,7 @@ Create two environments in Settings → Environments:
 
 **Preview Environment:**
 - Name: `preview`
-- URL: `https://phialo-design-preview.meise.workers.dev`
+- URL: `https://phialo-design-preview.lovebird.workers.dev`
 - No protection rules
 - Secrets:
   ```yaml

--- a/lighthouse-report.json
+++ b/lighthouse-report.json
@@ -1,9 +1,9 @@
 {
   "lighthouseVersion": "12.6.1",
-  "requestedUrl": "https://phialo-pr-393.meise.workers.dev/",
-  "mainDocumentUrl": "https://phialo-pr-393.meise.workers.dev/",
-  "finalDisplayedUrl": "https://phialo-pr-393.meise.workers.dev/",
-  "finalUrl": "https://phialo-pr-393.meise.workers.dev/",
+  "requestedUrl": "https://phialo-pr-393.lovebird.workers.dev/",
+  "mainDocumentUrl": "https://phialo-pr-393.lovebird.workers.dev/",
+  "finalDisplayedUrl": "https://phialo-pr-393.lovebird.workers.dev/",
+  "finalUrl": "https://phialo-pr-393.lovebird.workers.dev/",
   "fetchTime": "2025-08-20T06:49:51.988Z",
   "gatherMode": "navigation",
   "runWarnings": [],
@@ -244,7 +244,7 @@
             "description": "Failed to load resource: the server responded with a status of 404 ()",
             "sourceLocation": {
               "type": "source-location",
-              "url": "https://phialo-pr-393.meise.workers.dev/images/hero-bg.webp",
+              "url": "https://phialo-pr-393.lovebird.workers.dev/images/hero-bg.webp",
               "urlProvider": "network",
               "line": 0,
               "column": 0
@@ -255,7 +255,7 @@
             "description": "Failed to load resource: the server responded with a status of 404 ()",
             "sourceLocation": {
               "type": "source-location",
-              "url": "https://phialo-pr-393.meise.workers.dev/images/hero-bg.webp",
+              "url": "https://phialo-pr-393.lovebird.workers.dev/images/hero-bg.webp",
               "urlProvider": "network",
               "line": 0,
               "column": 0
@@ -274,7 +274,7 @@
             "description": "TypeError: Failed to resolve module specifier \"web-vitals/attribution\". Relative references must start with either \"/\", \"./\", or \"../\".",
             "sourceLocation": {
               "type": "source-location",
-              "url": "https://phialo-pr-393.meise.workers.dev/",
+              "url": "https://phialo-pr-393.lovebird.workers.dev/",
               "urlProvider": "network",
               "line": 0,
               "column": 0
@@ -285,7 +285,7 @@
             "description": "TypeError: Failed to resolve module specifier \"web-vitals/attribution\". Relative references must start with either \"/\", \"./\", or \"../\".",
             "sourceLocation": {
               "type": "source-location",
-              "url": "https://phialo-pr-393.meise.workers.dev/",
+              "url": "https://phialo-pr-393.lovebird.workers.dev/",
               "urlProvider": "network",
               "line": 0,
               "column": 0
@@ -323,7 +323,7 @@
         ],
         "items": [
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/",
             "responseTime": 43.836
           }
         ],
@@ -401,11 +401,11 @@
         ],
         "items": [
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/",
             "wastedMs": 3194.131556640625
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/",
             "wastedMs": 0
           }
         ],
@@ -567,7 +567,7 @@
         ],
         "items": [
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/",
             "total": 340.62000000000023,
             "scripting": 31.45600000000002,
             "scriptParseCompile": 6.327999999999996
@@ -579,7 +579,7 @@
             "scriptParseCompile": 0
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
             "total": 83.41999999999992,
             "scripting": 65.23999999999992,
             "scriptParseCompile": 0.504
@@ -729,7 +729,7 @@
         ],
         "items": [
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/",
             "sessionTargetType": "page",
             "protocol": "h2",
             "rendererStartTime": 0,
@@ -746,7 +746,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-400-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-400-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 43.07200002670288,
@@ -764,7 +764,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-700-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-700-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 43.21400010585785,
@@ -782,7 +782,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/images/hero-bg.webp",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/images/hero-bg.webp",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 43.26900005340576,
@@ -800,7 +800,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 43.32200002670288,
@@ -817,7 +817,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/about.DocD7zwn.css",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/about.DocD7zwn.css",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 43.361000061035156,
@@ -834,7 +834,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/page.PKP5U2SC.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/page.PKP5U2SC.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 43.3970000743866,
@@ -851,7 +851,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/LanguageSelector.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/LanguageSelector.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 43.43400013446808,
@@ -868,7 +868,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/Header.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/Header.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 43.47000002861023,
@@ -885,7 +885,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/portfolio",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/portfolio",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 44.09100008010864,
@@ -901,7 +901,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/services",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/services",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 44.12600004673004,
@@ -917,7 +917,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/Navigation.BakKnYdL.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/Navigation.BakKnYdL.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 94.51700007915497,
@@ -934,7 +934,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/client.CuZSJMhw.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/client.CuZSJMhw.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 94.61199998855591,
@@ -951,7 +951,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/AnimatedText.DrABy58R.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/AnimatedText.DrABy58R.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 95.08700001239777,
@@ -968,7 +968,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-500-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-500-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 97.82700002193451,
@@ -985,7 +985,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-600-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-600-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 97.88900005817413,
@@ -1002,7 +1002,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-700-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-700-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 97.95500004291534,
@@ -1019,7 +1019,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-500-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-500-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 97.99200010299683,
@@ -1036,7 +1036,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-400-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-400-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 98.03900003433228,
@@ -1053,7 +1053,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-300-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-300-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 98.10300004482269,
@@ -1070,7 +1070,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/images/homepage/portfolio-feature-800w.webp",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/images/homepage/portfolio-feature-800w.webp",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 111.79900002479553,
@@ -1087,7 +1087,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/images/homepage/3d-services-feature.png",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/images/homepage/3d-services-feature.png",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 111.87400007247925,
@@ -1104,7 +1104,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/react-vendor.up5wSyQh.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/react-vendor.up5wSyQh.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 114.62199997901917,
@@ -1121,7 +1121,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/SmoothScroll.CMwFRmuZ.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/SmoothScroll.CMwFRmuZ.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 118.75200009346008,
@@ -1138,7 +1138,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/portfolio/",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/portfolio/",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 124.70800006389618,
@@ -1155,7 +1155,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/services/",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/services/",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 125.61500000953674,
@@ -1172,7 +1172,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/AnimatedText.Bd4QR-6-.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/AnimatedText.Bd4QR-6-.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 136.04500007629395,
@@ -1189,7 +1189,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-600-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-600-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 191.60600006580353,
@@ -1206,7 +1206,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/manifest.json",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/manifest.json",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 237.1230001449585,
@@ -1223,7 +1223,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/favicon.svg",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/favicon.svg",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 237.3530000448227,
@@ -1240,7 +1240,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/~partytown/partytown-sandbox-sw.html?1755672592304",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/~partytown/partytown-sandbox-sw.html?1755672592304",
             "sessionTargetType": "page",
             "protocol": "http/1.1",
             "rendererStartTime": 243.4060001373291,
@@ -1256,7 +1256,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "blob:https://phialo-pr-393.meise.workers.dev/37f4ca1c-2196-4ff8-b6e4-9ab5a4c29268",
+            "url": "blob:https://phialo-pr-393.lovebird.workers.dev/37f4ca1c-2196-4ff8-b6e4-9ab5a4c29268",
             "sessionTargetType": "worker",
             "protocol": "blob",
             "rendererStartTime": 253.39800000190735,
@@ -1271,7 +1271,7 @@
             "priority": "VeryLow"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/",
             "sessionTargetType": "page",
             "protocol": "h2",
             "rendererStartTime": 330.43300008773804,
@@ -1288,7 +1288,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/favicon.svg",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/favicon.svg",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 355.7369999885559,
@@ -1305,7 +1305,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-400-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-400-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 378.2830001115799,
@@ -1323,7 +1323,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-700-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-700-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 378.44000005722046,
@@ -1341,7 +1341,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/images/hero-bg.webp",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/images/hero-bg.webp",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 378.49500012397766,
@@ -1359,7 +1359,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 378.5509999990463,
@@ -1376,7 +1376,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/about.DocD7zwn.css",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/about.DocD7zwn.css",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 378.5920001268387,
@@ -1393,7 +1393,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/page.PKP5U2SC.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/page.PKP5U2SC.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 378.6269999742508,
@@ -1410,7 +1410,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/LanguageSelector.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/LanguageSelector.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 378.69000005722046,
@@ -1427,7 +1427,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/Header.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/Header.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 378.74000012874603,
@@ -1444,7 +1444,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/portfolio",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/portfolio",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 383.07599997520447,
@@ -1461,7 +1461,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/services",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/services",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 383.1230000257492,
@@ -1478,7 +1478,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/Navigation.BakKnYdL.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/Navigation.BakKnYdL.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 399.09500002861023,
@@ -1495,7 +1495,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/client.CuZSJMhw.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/client.CuZSJMhw.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 399.1950000524521,
@@ -1512,7 +1512,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/AnimatedText.DrABy58R.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/AnimatedText.DrABy58R.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 399.6510000228882,
@@ -1529,7 +1529,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/react-vendor.up5wSyQh.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/react-vendor.up5wSyQh.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 401.1290000677109,
@@ -1546,7 +1546,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-500-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-500-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 407.3220000267029,
@@ -1563,7 +1563,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-600-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-600-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 407.4120000600815,
@@ -1580,7 +1580,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-700-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-700-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 407.47699999809265,
@@ -1597,7 +1597,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-500-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-500-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 407.51000010967255,
@@ -1614,7 +1614,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-400-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-400-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 407.55200004577637,
@@ -1631,7 +1631,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-300-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-300-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 407.61100006103516,
@@ -1648,7 +1648,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/images/homepage/portfolio-feature-800w.webp",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/images/homepage/portfolio-feature-800w.webp",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 410.36300003528595,
@@ -1665,7 +1665,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/images/homepage/3d-services-feature.png",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/images/homepage/3d-services-feature.png",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 410.42900002002716,
@@ -1682,7 +1682,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/AnimatedText.Bd4QR-6-.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/AnimatedText.Bd4QR-6-.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 413.2920000553131,
@@ -1699,7 +1699,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/SmoothScroll.CMwFRmuZ.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/SmoothScroll.CMwFRmuZ.js",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 413.48600006103516,
@@ -1716,7 +1716,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-600-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-600-latin.woff2",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 422.9490000009537,
@@ -1733,7 +1733,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/~partytown/partytown-sandbox-sw.html?1755672592493",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/~partytown/partytown-sandbox-sw.html?1755672592493",
             "sessionTargetType": "page",
             "protocol": "http/1.1",
             "rendererStartTime": 441.0770001411438,
@@ -1749,7 +1749,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "blob:https://phialo-pr-393.meise.workers.dev/f4e6e4c1-63eb-4ee6-a2b5-ae8753cae4a4",
+            "url": "blob:https://phialo-pr-393.lovebird.workers.dev/f4e6e4c1-63eb-4ee6-a2b5-ae8753cae4a4",
             "sessionTargetType": "worker",
             "protocol": "blob",
             "rendererStartTime": 482.5240001678467,
@@ -1764,7 +1764,7 @@
             "priority": "VeryLow"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/favicon.svg",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/favicon.svg",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 480.6779999732971,
@@ -1781,7 +1781,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/manifest.json",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/manifest.json",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 481.92900002002716,
@@ -1798,7 +1798,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/favicon.svg",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/favicon.svg",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 487.82600009441376,
@@ -1815,7 +1815,7 @@
             "entity": "workers.dev"
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/portfolio",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/portfolio",
             "sessionTargetType": "page",
             "protocol": "h3",
             "rendererStartTime": 715.2210000753403,
@@ -1864,7 +1864,7 @@
         ],
         "items": [
           {
-            "origin": "https://phialo-pr-393.meise.workers.dev",
+            "origin": "https://phialo-pr-393.lovebird.workers.dev",
             "rtt": 0.02
           }
         ],
@@ -1899,7 +1899,7 @@
         ],
         "items": [
           {
-            "origin": "https://phialo-pr-393.meise.workers.dev",
+            "origin": "https://phialo-pr-393.lovebird.workers.dev",
             "serverResponseTime": 35.68599999999999
           }
         ],
@@ -2472,7 +2472,7 @@
         "type": "treemap-data",
         "nodes": [
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/",
             "resourceBytes": 24802,
             "encodedBytes": 7682,
             "unusedBytes": 8782,
@@ -2560,67 +2560,67 @@
             ]
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
             "resourceBytes": 57007,
             "encodedBytes": 21182,
             "unusedBytes": 36846
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/page.PKP5U2SC.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/page.PKP5U2SC.js",
             "resourceBytes": 89,
             "encodedBytes": 89,
             "unusedBytes": 0
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/Header.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/Header.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
             "resourceBytes": 141,
             "encodedBytes": 113,
             "unusedBytes": 0
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/Navigation.BakKnYdL.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/Navigation.BakKnYdL.js",
             "resourceBytes": 5733,
             "encodedBytes": 2155,
             "unusedBytes": 1242
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/react-vendor.up5wSyQh.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/react-vendor.up5wSyQh.js",
             "resourceBytes": 266735,
             "encodedBytes": 85877,
             "unusedBytes": 138184
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/client.CuZSJMhw.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/client.CuZSJMhw.js",
             "resourceBytes": 141,
             "encodedBytes": 125,
             "unusedBytes": 0
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/SmoothScroll.CMwFRmuZ.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/SmoothScroll.CMwFRmuZ.js",
             "resourceBytes": 1175,
             "encodedBytes": 630,
             "unusedBytes": 581
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/AnimatedText.DrABy58R.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/AnimatedText.DrABy58R.js",
             "resourceBytes": 182,
             "encodedBytes": 147,
             "unusedBytes": 0
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/AnimatedText.Bd4QR-6-.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/AnimatedText.Bd4QR-6-.js",
             "resourceBytes": 881,
             "encodedBytes": 518,
             "unusedBytes": 173
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/LanguageSelector.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/LanguageSelector.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
             "resourceBytes": 141,
             "encodedBytes": 113,
             "unusedBytes": 0
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/~partytown/partytown-sandbox-sw.html?1755672592304",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/~partytown/partytown-sandbox-sw.html?1755672592304",
             "resourceBytes": 41629,
             "encodedBytes": 0,
             "unusedBytes": 4491,
@@ -2633,67 +2633,67 @@
             ]
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
             "resourceBytes": 57007,
             "encodedBytes": 21182,
             "unusedBytes": 34763
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/page.PKP5U2SC.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/page.PKP5U2SC.js",
             "resourceBytes": 89,
             "encodedBytes": 89,
             "unusedBytes": 0
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/Navigation.BakKnYdL.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/Navigation.BakKnYdL.js",
             "resourceBytes": 5733,
             "encodedBytes": 2155,
             "unusedBytes": 1242
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/react-vendor.up5wSyQh.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/react-vendor.up5wSyQh.js",
             "resourceBytes": 266735,
             "encodedBytes": 85877,
             "unusedBytes": 137845
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/Header.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/Header.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
             "resourceBytes": 141,
             "encodedBytes": 113,
             "unusedBytes": 0
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/LanguageSelector.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/LanguageSelector.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
             "resourceBytes": 141,
             "encodedBytes": 113,
             "unusedBytes": 0
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/client.CuZSJMhw.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/client.CuZSJMhw.js",
             "resourceBytes": 141,
             "encodedBytes": 125,
             "unusedBytes": 0
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/AnimatedText.DrABy58R.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/AnimatedText.DrABy58R.js",
             "resourceBytes": 182,
             "encodedBytes": 147,
             "unusedBytes": 0
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/AnimatedText.Bd4QR-6-.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/AnimatedText.Bd4QR-6-.js",
             "resourceBytes": 881,
             "encodedBytes": 518,
             "unusedBytes": 173
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/_astro/SmoothScroll.CMwFRmuZ.js",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/_astro/SmoothScroll.CMwFRmuZ.js",
             "resourceBytes": 1175,
             "encodedBytes": 630,
             "unusedBytes": 581
           },
           {
-            "name": "https://phialo-pr-393.meise.workers.dev/~partytown/partytown-sandbox-sw.html?1755672592493",
+            "name": "https://phialo-pr-393.lovebird.workers.dev/~partytown/partytown-sandbox-sw.html?1755672592493",
             "resourceBytes": 41629,
             "encodedBytes": 0,
             "unusedBytes": 4557,
@@ -3423,43 +3423,43 @@
         ],
         "items": [
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/images/homepage/3d-services-feature.png",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/images/homepage/3d-services-feature.png",
             "totalBytes": 449231
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/react-vendor.up5wSyQh.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/react-vendor.up5wSyQh.js",
             "totalBytes": 87196
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/images/hero-bg.webp",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/images/hero-bg.webp",
             "totalBytes": 46229
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/images/hero-bg.webp",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/images/hero-bg.webp",
             "totalBytes": 46229
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/images/homepage/portfolio-feature-800w.webp",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/images/homepage/portfolio-feature-800w.webp",
             "totalBytes": 27024
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-500-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-500-latin.woff2",
             "totalBytes": 25867
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-600-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-600-latin.woff2",
             "totalBytes": 25794
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-700-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-700-latin.woff2",
             "totalBytes": 25589
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-300-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-300-latin.woff2",
             "totalBytes": 25510
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-400-latin.woff2",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-400-latin.woff2",
             "totalBytes": 25004
           }
         ],
@@ -3663,13 +3663,13 @@
         ],
         "items": [
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/react-vendor.up5wSyQh.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/react-vendor.up5wSyQh.js",
             "totalBytes": 85876,
             "wastedBytes": 44489,
             "wastedPercent": 51.80572478302435
           },
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/react-vendor.up5wSyQh.js",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/react-vendor.up5wSyQh.js",
             "totalBytes": 85876,
             "wastedBytes": 44379,
             "wastedPercent": 51.6786323504602
@@ -4602,60 +4602,60 @@
         "type": "network-tree",
         "chains": {
           "5A5E9AB05C7A96DF589C9B301284EDA9": {
-            "url": "https://phialo-pr-393.meise.workers.dev/",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/",
             "navStartToEndTime": 52,
             "transferSize": 0,
             "isLongest": true,
             "children": {
               "85280.69": {
-                "url": "https://phialo-pr-393.meise.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
+                "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/ClientRouter.astro_astro_type_script_index_0_lang.B162YBf1.js",
                 "navStartToEndTime": 70,
                 "transferSize": 0,
                 "children": {}
               },
               "85280.70": {
-                "url": "https://phialo-pr-393.meise.workers.dev/_astro/about.DocD7zwn.css",
+                "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/about.DocD7zwn.css",
                 "navStartToEndTime": 67,
                 "transferSize": 0,
                 "children": {
                   "85280.113": {
-                    "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-500-latin.woff2",
+                    "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-500-latin.woff2",
                     "navStartToEndTime": 91,
                     "transferSize": 0,
                     "children": {}
                   },
                   "85280.110": {
-                    "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-600-latin.woff2",
+                    "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-600-latin.woff2",
                     "navStartToEndTime": 91,
                     "transferSize": 0,
                     "children": {}
                   },
                   "85280.111": {
-                    "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-700-latin.woff2",
+                    "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-700-latin.woff2",
                     "navStartToEndTime": 91,
                     "transferSize": 0,
                     "children": {}
                   },
                   "85280.109": {
-                    "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-500-latin.woff2",
+                    "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-500-latin.woff2",
                     "navStartToEndTime": 92,
                     "transferSize": 0,
                     "children": {}
                   },
                   "85280.112": {
-                    "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-400-latin.woff2",
+                    "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-400-latin.woff2",
                     "navStartToEndTime": 82,
                     "transferSize": 0,
                     "children": {}
                   },
                   "85280.107": {
-                    "url": "https://phialo-pr-393.meise.workers.dev/fonts/inter-300-latin.woff2",
+                    "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/inter-300-latin.woff2",
                     "navStartToEndTime": 92,
                     "transferSize": 0,
                     "children": {}
                   },
                   "85280.114": {
-                    "url": "https://phialo-pr-393.meise.workers.dev/fonts/playfair-600-latin.woff2",
+                    "url": "https://phialo-pr-393.lovebird.workers.dev/fonts/playfair-600-latin.woff2",
                     "navStartToEndTime": 96,
                     "transferSize": 0,
                     "children": {}
@@ -4663,18 +4663,18 @@
                 }
               },
               "85280.71": {
-                "url": "https://phialo-pr-393.meise.workers.dev/_astro/page.PKP5U2SC.js",
+                "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/page.PKP5U2SC.js",
                 "navStartToEndTime": 70,
                 "transferSize": 0,
                 "children": {}
               },
               "85280.72": {
-                "url": "https://phialo-pr-393.meise.workers.dev/_astro/LanguageSelector.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
+                "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/LanguageSelector.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
                 "navStartToEndTime": 70,
                 "transferSize": 0,
                 "children": {
                   "85280.105": {
-                    "url": "https://phialo-pr-393.meise.workers.dev/_astro/react-vendor.up5wSyQh.js",
+                    "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/react-vendor.up5wSyQh.js",
                     "navStartToEndTime": 85,
                     "transferSize": 0,
                     "children": {}
@@ -4682,30 +4682,30 @@
                 }
               },
               "85280.73": {
-                "url": "https://phialo-pr-393.meise.workers.dev/_astro/Header.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
+                "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/Header.astro_astro_type_script_index_0_lang.CCS5uSzY.js",
                 "navStartToEndTime": 70,
                 "transferSize": 0,
                 "children": {}
               },
               "85280.93": {
-                "url": "https://phialo-pr-393.meise.workers.dev/_astro/Navigation.BakKnYdL.js",
+                "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/Navigation.BakKnYdL.js",
                 "navStartToEndTime": 73,
                 "transferSize": 0,
                 "children": {}
               },
               "85280.94": {
-                "url": "https://phialo-pr-393.meise.workers.dev/_astro/client.CuZSJMhw.js",
+                "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/client.CuZSJMhw.js",
                 "navStartToEndTime": 74,
                 "transferSize": 0,
                 "children": {}
               },
               "85280.98": {
-                "url": "https://phialo-pr-393.meise.workers.dev/_astro/AnimatedText.DrABy58R.js",
+                "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/AnimatedText.DrABy58R.js",
                 "navStartToEndTime": 82,
                 "transferSize": 0,
                 "children": {
                   "85280.123": {
-                    "url": "https://phialo-pr-393.meise.workers.dev/_astro/AnimatedText.Bd4QR-6-.js",
+                    "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/AnimatedText.Bd4QR-6-.js",
                     "navStartToEndTime": 100,
                     "transferSize": 0,
                     "children": {}
@@ -4713,7 +4713,7 @@
                 }
               },
               "85280.124": {
-                "url": "https://phialo-pr-393.meise.workers.dev/_astro/SmoothScroll.CMwFRmuZ.js",
+                "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/SmoothScroll.CMwFRmuZ.js",
                 "navStartToEndTime": 101,
                 "transferSize": 0,
                 "isLongest": true,
@@ -4762,7 +4762,7 @@
         ],
         "items": [
           {
-            "url": "https://phialo-pr-393.meise.workers.dev/_astro/about.DocD7zwn.css",
+            "url": "https://phialo-pr-393.lovebird.workers.dev/_astro/about.DocD7zwn.css",
             "totalBytes": 0
           }
         ]
@@ -5899,7 +5899,7 @@
     {
       "name": "workers.dev",
       "origins": [
-        "https://phialo-pr-393.meise.workers.dev"
+        "https://phialo-pr-393.lovebird.workers.dev"
       ],
       "isFirstParty": true,
       "isUnrecognized": true

--- a/phialo-design/docs/how-to/DEPLOY.md
+++ b/phialo-design/docs/how-to/DEPLOY.md
@@ -34,8 +34,8 @@ This guide covers deployment workflows for the Phialo Design website using Cloud
 | Environment | URL | Purpose |
 |------------|-----|---------|
 | Production | https://phialo.de | Live website |
-| Master | https://phialo-master.meise.workers.dev | Latest master branch |
-| Preview | https://phialo-pr-{number}.meise.workers.dev | PR previews |
+| Master | https://phialo-master.lovebird.workers.dev | Latest master branch |
+| Preview | https://phialo-pr-{number}.lovebird.workers.dev | PR previews |
 
 ## Quick Start
 
@@ -85,13 +85,13 @@ pnpm run dev
 - **File**: `.github/workflows/deploy-master.yml`
 - **Trigger**: Push to master branch
 - **Environment**: preview (shared with PR previews)
-- **URL**: https://phialo-master.meise.workers.dev
+- **URL**: https://phialo-master.lovebird.workers.dev
 
 ### PR Preview
 - **File**: `.github/workflows/cloudflare-pr-preview.yml`
 - **Trigger**: PR opened/updated
 - **Environment**: preview
-- **URL**: https://phialo-pr-{number}.meise.workers.dev
+- **URL**: https://phialo-pr-{number}.lovebird.workers.dev
 
 When you create or update a PR that modifies files in `workers/` or `phialo-design/`, the workflow automatically:
 1. Builds the Astro site

--- a/phialo-design/docs/how-to/ENVIRONMENT-SETUP-GUIDE.md
+++ b/phialo-design/docs/how-to/ENVIRONMENT-SETUP-GUIDE.md
@@ -24,8 +24,8 @@ This is the **single source of truth** for setting up deployment environments fo
 | Environment | Purpose | URL | Branch |
 |------------|---------|-----|--------|
 | `production` | Live website | https://phialo.de | master |
-| `preview` | PR previews | https://phialo-design-preview.meise.workers.dev | any |
-| `master` | Latest master | https://phialo-master.meise.workers.dev | master |
+| `preview` | PR previews | https://phialo-design-preview.lovebird.workers.dev | any |
+| `master` | Latest master | https://phialo-master.lovebird.workers.dev | master |
 
 ## Prerequisites
 
@@ -128,8 +128,8 @@ For production deployment to use a custom domain (e.g., phialo.de):
    - Site name: `phialo-design-[environment]`
    - Hostname: 
      - Production: `phialo.de`
-     - Preview: `phialo-design-preview.meise.workers.dev`
-     - Master: `phialo-master.meise.workers.dev`
+     - Preview: `phialo-design-preview.lovebird.workers.dev`
+     - Master: `phialo-master.lovebird.workers.dev`
    - Click `Done`
 
 3. **Get Analytics Token**
@@ -152,7 +152,7 @@ For production deployment to use a custom domain (e.g., phialo.de):
    - Domains: 
      - Production: `phialo.de`
      - Preview: `*.workers.dev`
-     - Master: `phialo-master.meise.workers.dev`
+     - Master: `phialo-master.lovebird.workers.dev`
 
 3. **Configure Widget**
    - Widget Mode: `Managed`
@@ -261,7 +261,7 @@ Secrets: All 8 secrets required
 ### Preview Environment
 ```yaml
 Name: preview  
-URL: https://phialo-design-preview.meise.workers.dev
+URL: https://phialo-design-preview.lovebird.workers.dev
 Branch: any (typically PR branches)
 Protection: None
 Secrets: All 8 secrets required
@@ -270,7 +270,7 @@ Secrets: All 8 secrets required
 ### Master Environment
 ```yaml
 Name: master
-URL: https://phialo-master.meise.workers.dev
+URL: https://phialo-master.lovebird.workers.dev
 Branch: master
 Protection: None
 Secrets: All 8 secrets required

--- a/phialo-design/docs/how-to/configure-turnstile-production.md
+++ b/phialo-design/docs/how-to/configure-turnstile-production.md
@@ -44,8 +44,8 @@ In the Cloudflare Dashboard:
    localhost
    localhost:4321
    localhost:4322
-   phialo-master.meise.workers.dev
-   phialo-pr-*.meise.workers.dev
+   phialo-master.lovebird.workers.dev
+   phialo-pr-*.lovebird.workers.dev
    ```
 
 3. Enable these settings:

--- a/phialo-design/docs/how-to/manual-deployments.md
+++ b/phialo-design/docs/how-to/manual-deployments.md
@@ -116,7 +116,7 @@ If you provide a `callback_url`, the workflow will POST back:
 {
   "status": "success",
   "environment": "preview",
-  "url": "https://phialo-design-preview.meise.workers.dev",
+  "url": "https://phialo-design-preview.lovebird.workers.dev",
   "deployed_at": "2025-06-29T10:30:00Z",
   "run_id": "123456789"
 }
@@ -236,8 +236,8 @@ npx wrangler rollback --env production
 
 ### Deployment URLs:
 - **Production**: https://phialo.de
-- **Preview**: https://phialo-design-preview.meise.workers.dev
-- **PR Preview**: https://phialo-pr-{number}.meise.workers.dev
+- **Preview**: https://phialo-design-preview.lovebird.workers.dev
+- **PR Preview**: https://phialo-pr-{number}.lovebird.workers.dev
 
 ### Required Secrets:
 - `CLOUDFLARE_API_TOKEN`: For authentication

--- a/phialo-design/docs/how-to/performance-check-v2-migration.md
+++ b/phialo-design/docs/how-to/performance-check-v2-migration.md
@@ -12,7 +12,7 @@ Performance Check v2 addresses two critical issues with the current performance 
 
 #### 1. Tests Against Real Deployments
 - **Before**: Tests ran against `localhost:4322` (local preview server)
-- **After**: Tests run against deployed PR preview URLs (`https://phialo-pr-{number}.meise.workers.dev`)
+- **After**: Tests run against deployed PR preview URLs (`https://phialo-pr-{number}.lovebird.workers.dev`)
 - **Benefit**: Real-world performance metrics including CDN, edge caching, and actual network latency
 
 #### 2. Collapsible Report Format
@@ -75,7 +75,7 @@ Performance Check v2 addresses two critical issues with the current performance 
 ```markdown
 ## 📊 Core Web Vitals Report
 
-**Test Environment:** 🌐 https://phialo-pr-123.meise.workers.dev
+**Test Environment:** 🌐 https://phialo-pr-123.lovebird.workers.dev
 **Test Date:** 2025-01-24
 
 ### ✅ Excellent - Overall Score: 92/100

--- a/phialo-design/docs/how-to/setup-turnstile-preclearance.md
+++ b/phialo-design/docs/how-to/setup-turnstile-preclearance.md
@@ -53,8 +53,8 @@ The implementation uses a centralized token management system that:
      - `127.0.0.1` (IP-based access)
      - `phialo.de` (production domain)
      - `*.phialo.de` (subdomains)
-     - `phialo-master.meise.workers.dev` (master preview)
-     - `phialo-pr-*.meise.workers.dev` (PR previews)
+     - `phialo-master.lovebird.workers.dev` (master preview)
+     - `phialo-pr-*.lovebird.workers.dev` (PR previews)
 
 > **Important**: Turnstile requires explicit domain configuration. If you see Error 110200, it means the current domain is not in the allowed list.
 
@@ -255,8 +255,8 @@ This warning is **expected behavior** on workers.dev domains and does not affect
 | Environment | Basic Protection | Pre-clearance | Notes |
 |------------|------------------|---------------|-------|
 | `localhost:4321` | ✅ Works | ✅ Works* | *With test keys only |
-| `phialo-pr-*.meise.workers.dev` | ✅ Works | ❌ Not supported | Console warning expected |
-| `phialo-master.meise.workers.dev` | ✅ Works | ❌ Not supported | Console warning expected |
+| `phialo-pr-*.lovebird.workers.dev` | ✅ Works | ❌ Not supported | Console warning expected |
+| `phialo-master.lovebird.workers.dev` | ✅ Works | ❌ Not supported | Console warning expected |
 | `phialo.de` (production) | ✅ Works | ✅ Works | Full functionality |
 
 **Testing Recommendations**:

--- a/phialo-design/public/sw.js
+++ b/phialo-design/public/sw.js
@@ -96,7 +96,7 @@ self.addEventListener('fetch', (event) => {
     url.origin === self.location.origin ||
     url.hostname === 'phialo.de' ||
     url.hostname === 'www.phialo.de' ||
-    url.hostname.match(/^phialo-(pr-\d+|master|preview)\.meise\.workers\.dev$/) ||
+    url.hostname.match(/^phialo-(pr-\d+|master|preview)\.lovebird\.workers\.dev$/) ||
     url.hostname === 'localhost' ||
     url.hostname === '127.0.0.1';
     
@@ -355,7 +355,7 @@ self.addEventListener('message', (event) => {
     }
     
     // Allow Cloudflare Workers preview deployments
-    if (origin.match(/^https:\/\/phialo-(pr-\d+|master|preview)\.meise\.workers\.dev$/)) {
+    if (origin.match(/^https:\/\/phialo-(pr-\d+|master|preview)\.lovebird\.workers\.dev$/)) {
       return true;
     }
     

--- a/phialo-design/src/i18n/ui.ts
+++ b/phialo-design/src/i18n/ui.ts
@@ -33,12 +33,6 @@ export const ui = {
     'about.intro': 'Willkommen bei Phialo Design, wo jedes Schmuckstück eine Geschichte erzählt. Mit über 20 Jahren Erfahrung in der Schmuckherstellung verbinden wir traditionelle Handwerkskunst mit zeitgenössischem Design.',
     'about.philosophy': 'Unsere Philosophie ist einfach: Jedes Stück sollte zeitlos, elegant und einzigartig sein. Wir glauben an die Schönheit der Einfachheit und die Kraft des Details.',
     'about.materials': 'Wir arbeiten ausschließlich mit den feinsten Materialien - von konfliktfreien Diamanten bis zu ethisch gewonnenem Gold und Silber. Nachhaltigkeit und Qualität stehen im Mittelpunkt unseres Schaffens.',
-    'about.team.heading': 'Unser Team',
-    'about.team.founder': 'Gründerin & Designerin',
-    'about.team.cofounder': 'Co-Founder & IT',
-    'about.team.founder.bio': 'Mit einer Leidenschaft für zeitloses Design und nachhaltigen Luxus leitet Gesa Meise die kreative Vision von Phialo Design. Ihre langjährige Erfahrung in traditionellen Goldschmiedetechniken verbindet sie mit modernen Designansätzen.',
-    'about.team.cofounder.bio': 'Als technischer Visionär bringt Bartholomäus Dedersen digitale Innovation zu Phialo Design. Seine Expertise in modernen Technologien ermöglicht es uns, traditionelles Handwerk mit digitaler Exzellenz zu verbinden.',
-    
     // Contact Page
     'contact.title': 'Kontakt - Phialo Design',
     'contact.description': 'Nehmen Sie Kontakt mit uns auf für individuelle Schmuckanfertigungen oder Fragen zu unseren Kollektionen.',
@@ -119,12 +113,6 @@ export const ui = {
     'about.intro': 'Welcome to Phialo Design, where every piece of jewelry tells a story. With over 20 years of experience in jewelry making, we combine traditional craftsmanship with contemporary design.',
     'about.philosophy': 'Our philosophy is simple: Every piece should be timeless, elegant, and unique. We believe in the beauty of simplicity and the power of detail.',
     'about.materials': 'We work exclusively with the finest materials - from conflict-free diamonds to ethically sourced gold and silver. Sustainability and quality are at the heart of our creations.',
-    'about.team.heading': 'Our Team',
-    'about.team.founder': 'Founder & Designer',
-    'about.team.cofounder': 'Co-Founder & IT',
-    'about.team.founder.bio': 'With a passion for timeless design and sustainable luxury, Gesa Meise leads the creative vision of Phialo Design. She combines years of experience in traditional goldsmithing techniques with modern design approaches.',
-    'about.team.cofounder.bio': 'As a technical visionary, Bartholomäus Dedersen brings digital innovation to Phialo Design. His expertise in modern technologies enables us to combine traditional craftsmanship with digital excellence.',
-    
     // Contact Page
     'contact.title': 'Contact - Phialo Design',
     'contact.description': 'Get in touch with us for custom jewelry orders or questions about our collections.',

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -132,7 +132,7 @@ deploy_cli() {
     if [ "$ENVIRONMENT" = "production" ]; then
         echo -e "URL: ${YELLOW}https://phialo.de${NC}"
     else
-        echo -e "URL: ${YELLOW}https://phialo-design-preview.meise.workers.dev${NC}"
+        echo -e "URL: ${YELLOW}https://phialo-design-preview.lovebird.workers.dev${NC}"
     fi
 }
 


### PR DESCRIPTION
Cleans up stale meise.workers.dev references, standardizes preview URLs on lovebird.workers.dev, and removes unused legacy team translation keys.